### PR TITLE
fix xorm models with wrong name, using mapping name

### DIFF
--- a/internal/models/business_group.go
+++ b/internal/models/business_group.go
@@ -5,7 +5,7 @@ import (
 )
 
 type BusinessGroup struct {
-	ID        int64     `json:"id" xorm:"pk autoincr"`
+	ID        int64     `json:"id" xorm:"'id' pk autoincr"`
 	Name      string    `json:"name" xorm:"VARCHAR(255) not null comment('商户名称')"`
 	Status    string    `json:"status" xorm:"VARCHAR(10) not null comment('状态｜invalid｜valid')"`
 	CreatedAt time.Time `json:"created_at" xorm:"created"`


### PR DESCRIPTION
Problem: starting up the app, and test using the default example, got error "Error 1054: Unknown column 'i_d' in 'field list'"

Cause: bussiness_group.go struct "BusinessGroup", it's ID field with the wrong name, xorm uses SnakeMapper defaultly, So the name converted into 'i_d' 

Reference: https://lunny.gitbooks.io/xorm-manual-zh-cn/content/chapter-02/3.tags.html
